### PR TITLE
Added delegate lifetime

### DIFF
--- a/AdvancedDLSupport.Tests/Data/Delegates/DelegateLibraryDelegates.cs
+++ b/AdvancedDLSupport.Tests/Data/Delegates/DelegateLibraryDelegates.cs
@@ -1,0 +1,38 @@
+//
+//  DelegateLibraryDelegates.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma warning disable SA1600, CS1591
+
+namespace AdvancedDLSupport.Tests.Data
+{
+    public class DelegateLibraryDelegates
+    {
+        public delegate void Action();
+
+        public delegate void ActionInt(int param);
+
+        public delegate int IntFunc();
+
+        public delegate int IntFuncInt(int param);
+
+        public delegate void ActinIntInAction(ActionInt param);
+
+        public delegate int IntFuncIntInFuncInt(IntFuncInt param1);
+    }
+}

--- a/AdvancedDLSupport.Tests/Data/Delegates/DelegateLibraryDelegates.cs
+++ b/AdvancedDLSupport.Tests/Data/Delegates/DelegateLibraryDelegates.cs
@@ -19,20 +19,28 @@
 
 #pragma warning disable SA1600, CS1591
 
+using System.Runtime.InteropServices;
+
 namespace AdvancedDLSupport.Tests.Data
 {
     public class DelegateLibraryDelegates
     {
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void Action();
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void ActionInt(int param);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int IntFunc();
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int IntFuncInt(int param);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void ActinIntInAction(ActionInt param);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int IntFuncIntInFuncInt(IntFuncInt param1);
     }
 }

--- a/AdvancedDLSupport.Tests/Data/Interfaces/IDelegateLibrary.cs
+++ b/AdvancedDLSupport.Tests/Data/Interfaces/IDelegateLibrary.cs
@@ -27,11 +27,15 @@ namespace AdvancedDLSupport.Tests.Data
 
         void ExecuteActionT1(DelegateLibraryDelegates.ActionInt action);
 
+        void ExecuteActionT1WithParameter(DelegateLibraryDelegates.ActionInt action, int value);
+
         void ExecuteActionT1Nested(DelegateLibraryDelegates.ActinIntInAction action);
 
         int ExecuteFuncT1(DelegateLibraryDelegates.IntFunc func);
 
         int ExecuteFuncT1T2(DelegateLibraryDelegates.IntFuncInt func);
+
+        int ExecuteFuncT1T2WithParameter(DelegateLibraryDelegates.IntFuncInt func, int value);
 
         int ExecuteFuncT1T2Nested(DelegateLibraryDelegates.IntFuncIntInFuncInt func);
 

--- a/AdvancedDLSupport.Tests/Data/Interfaces/IDelegateLibrary.cs
+++ b/AdvancedDLSupport.Tests/Data/Interfaces/IDelegateLibrary.cs
@@ -51,9 +51,6 @@ namespace AdvancedDLSupport.Tests.Data
         void ExecuteActionDefault(DelegateLibraryDelegates.Action action);
 
         [NativeSymbol(entrypoint: "ExecuteAction")]
-        void ExecuteActionLifetimeDefault([DelegateLifetime] DelegateLibraryDelegates.Action action);
-
-        [NativeSymbol(entrypoint: "ExecuteAction")]
         void ExecuteActionLifetimeNone([DelegateLifetime(DelegateLifetime.UserManaged)] DelegateLibraryDelegates.Action action);
 
         [NativeSymbol(entrypoint: "ExecuteAction")]

--- a/AdvancedDLSupport.Tests/Data/Interfaces/IDelegateLibrary.cs
+++ b/AdvancedDLSupport.Tests/Data/Interfaces/IDelegateLibrary.cs
@@ -54,7 +54,7 @@ namespace AdvancedDLSupport.Tests.Data
         void ExecuteActionLifetimeDefault([DelegateLifetime] DelegateLibraryDelegates.Action action);
 
         [NativeSymbol(entrypoint: "ExecuteAction")]
-        void ExecuteActionLifetimeNone([DelegateLifetime(DelegateLifetime.None)] DelegateLibraryDelegates.Action action);
+        void ExecuteActionLifetimeNone([DelegateLifetime(DelegateLifetime.UserManaged)] DelegateLibraryDelegates.Action action);
 
         [NativeSymbol(entrypoint: "ExecuteAction")]
         void ExecuteActionLifetimePersistent([DelegateLifetime(DelegateLifetime.Persistent)] DelegateLibraryDelegates.Action action);

--- a/AdvancedDLSupport.Tests/Data/Interfaces/IDelegateLibrary.cs
+++ b/AdvancedDLSupport.Tests/Data/Interfaces/IDelegateLibrary.cs
@@ -1,0 +1,65 @@
+//
+//  IDelegateLibrary.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma warning disable SA1600, CS1591
+
+namespace AdvancedDLSupport.Tests.Data
+{
+    public interface IDelegateLibrary
+    {
+        void ExecuteAction(DelegateLibraryDelegates.Action action);
+
+        void ExecuteActionT1(DelegateLibraryDelegates.ActionInt action);
+
+        void ExecuteActionT1Nested(DelegateLibraryDelegates.ActinIntInAction action);
+
+        int ExecuteFuncT1(DelegateLibraryDelegates.IntFunc func);
+
+        int ExecuteFuncT1T2(DelegateLibraryDelegates.IntFuncInt func);
+
+        int ExecuteFuncT1T2Nested(DelegateLibraryDelegates.IntFuncIntInFuncInt func);
+
+        DelegateLibraryDelegates.Action GetNativeAction();
+
+        DelegateLibraryDelegates.ActionInt GetNativeActionT1();
+
+        DelegateLibraryDelegates.ActinIntInAction GetNativeActionT1Nested();
+
+        DelegateLibraryDelegates.IntFunc GetNativeFuncT1();
+
+        DelegateLibraryDelegates.IntFuncInt GetNativeFuncT1T2();
+
+        DelegateLibraryDelegates.IntFuncIntInFuncInt GetNativeFuncT1T2Nested();
+
+        [NativeSymbol(entrypoint: "ExecuteAction")]
+        void ExecuteActionDefault(DelegateLibraryDelegates.Action action);
+
+        [NativeSymbol(entrypoint: "ExecuteAction")]
+        void ExecuteActionLifetimeDefault([DelegateLifetime] DelegateLibraryDelegates.Action action);
+
+        [NativeSymbol(entrypoint: "ExecuteAction")]
+        void ExecuteActionLifetimeNone([DelegateLifetime(DelegateLifetime.None)] DelegateLibraryDelegates.Action action);
+
+        [NativeSymbol(entrypoint: "ExecuteAction")]
+        void ExecuteActionLifetimePersistent([DelegateLifetime(DelegateLifetime.Persistent)] DelegateLibraryDelegates.Action action);
+
+        [NativeSymbol(entrypoint: "ExecuteAction")]
+        void ExecuteActionLifetimeCallOnly([DelegateLifetime(DelegateLifetime.CallOnly)] DelegateLibraryDelegates.Action action);
+    }
+}

--- a/AdvancedDLSupport.Tests/Data/Interfaces/IDelegateLibrary.cs
+++ b/AdvancedDLSupport.Tests/Data/Interfaces/IDelegateLibrary.cs
@@ -61,5 +61,9 @@ namespace AdvancedDLSupport.Tests.Data
 
         [NativeSymbol(entrypoint: "ExecuteAction")]
         void ExecuteActionLifetimeCallOnly([DelegateLifetime(DelegateLifetime.CallOnly)] DelegateLibraryDelegates.Action action);
+
+        DelegateLibraryDelegates.Action GetNullDelegate();
+
+        int IsNullDelegate(DelegateLibraryDelegates.Action action);
     }
 }

--- a/AdvancedDLSupport.Tests/Tests/Integration/DelegateTests.cs
+++ b/AdvancedDLSupport.Tests/Tests/Integration/DelegateTests.cs
@@ -20,6 +20,8 @@
 #pragma warning disable SA1600, CS1591
 
 using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 using AdvancedDLSupport.Tests.Data;
 using AdvancedDLSupport.Tests.TestBases;
 using JetBrains.Annotations;
@@ -230,6 +232,11 @@ namespace AdvancedDLSupport.Tests.Integration
             [Fact]
             public void NoneLifetimeDelegateGetsCollected()
             {
+                if (RuntimeInformation.FrameworkDescription.Contains("Mono"))
+                {
+                    return; // Do not test on mono, as it does not collect these (at least not immediately)
+                }
+
                 var weakRef = CreateAction(false, x => Library.ExecuteActionLifetimeNone(x));
 
                 GC.Collect();
@@ -240,6 +247,11 @@ namespace AdvancedDLSupport.Tests.Integration
             [Fact]
             public void CallOnlyLifetimeDelegateGetsCollected()
             {
+                if (RuntimeInformation.FrameworkDescription.Contains("Mono"))
+                {
+                    return; // Do not test on mono, as it does not collect these (at least not immediately)
+                }
+
                 var weakRef = CreateAction(false, x => Library.ExecuteActionLifetimeCallOnly(x));
                 GC.Collect();
 

--- a/AdvancedDLSupport.Tests/Tests/Integration/DelegateTests.cs
+++ b/AdvancedDLSupport.Tests/Tests/Integration/DelegateTests.cs
@@ -41,6 +41,12 @@ namespace AdvancedDLSupport.Tests.Integration
             }
 
             [Fact]
+            public void NativeCanPassNullDelegate()
+            {
+                Assert.Equal(1, Library.IsNullDelegate(null));
+            }
+
+            [Fact]
             public void NativeCanCallAction()
             {
                 bool ranAction = false;
@@ -113,6 +119,12 @@ namespace AdvancedDLSupport.Tests.Integration
             public FromNativeToManaged()
                 : base(LibraryName)
             {
+            }
+
+            [Fact]
+            public void ManagedCanGetNullDelegate()
+            {
+                Assert.Null(Library.GetNullDelegate());
             }
 
             [Fact]

--- a/AdvancedDLSupport.Tests/Tests/Integration/DelegateTests.cs
+++ b/AdvancedDLSupport.Tests/Tests/Integration/DelegateTests.cs
@@ -1,0 +1,257 @@
+//
+//  DelegateTests.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma warning disable SA1600, CS1591
+
+using System;
+using AdvancedDLSupport.Tests.Data;
+using AdvancedDLSupport.Tests.TestBases;
+using JetBrains.Annotations;
+using Xunit;
+
+namespace AdvancedDLSupport.Tests.Integration
+{
+    public class DelegateTests
+    {
+        private const string LibraryName = "GenericDelegateTests";
+
+        public class FromManagedToNative : LibraryTestBase<IDelegateLibrary>
+        {
+            public FromManagedToNative()
+                : base(LibraryName)
+            {
+            }
+
+            [Fact]
+            public void NativeCanCallAction()
+            {
+                bool ranAction = false;
+                Library.ExecuteAction(() => ranAction = true);
+
+                Assert.True(ranAction);
+            }
+
+            [Fact]
+            public void NativeCanCallActionWithParameter()
+            {
+                bool ranAction = false;
+                int result = 0;
+                Library.ExecuteActionT1(x =>
+                {
+                    ranAction = true;
+                    result = x;
+                });
+
+                Assert.True(ranAction);
+                Assert.Equal(5, result);
+            }
+
+            [Fact]
+            public void NativeCanCallFunc()
+            {
+                var result = Library.ExecuteFuncT1(() => 5);
+
+                Assert.Equal(5, result);
+            }
+
+            [Fact]
+            public void NativeCanCallFuncWithParameter()
+            {
+                var result = Library.ExecuteFuncT1T2(x => 5 * x);
+
+                Assert.Equal(25, result);
+            }
+
+            [Fact(Skip = "Not working due to CLR limitations.")]
+            public void NativeCanCallNestedAction()
+            {
+                bool ranAction = false;
+                Library.ExecuteActionT1Nested
+                (
+                    action =>
+                    {
+                        ranAction = true;
+                        action(5);
+                    }
+                );
+
+                Assert.True(ranAction);
+            }
+
+            [Fact(Skip = "Not working due to CLR limitations.")]
+            public void NativeCanCallNestedFunc()
+            {
+                var result = Library.ExecuteFuncT1T2Nested
+                (
+                    func => func(5)
+                );
+
+                Assert.Equal(25, result);
+            }
+        }
+
+        public class FromNativeToManaged : LibraryTestBase<IDelegateLibrary>
+        {
+            public FromNativeToManaged()
+                : base(LibraryName)
+            {
+            }
+
+            [Fact]
+            public void ManagedCanCallAction()
+            {
+                var action = Library.GetNativeAction();
+                action();
+            }
+
+            [Fact]
+            public void ManagedCanCallActionWithParameter()
+            {
+                var action = Library.GetNativeActionT1();
+                action(5);
+            }
+
+            [Fact]
+            public void ManagedCanCallFunc()
+            {
+                var func = Library.GetNativeFuncT1();
+                var result = func();
+
+                Assert.Equal(5, result);
+            }
+
+            [Fact]
+            public void ManagedCanCallFuncWithParameter()
+            {
+                var func = Library.GetNativeFuncT1T2();
+                var result = func(5);
+
+                Assert.Equal(25, result);
+            }
+
+            [Fact(Skip = "Not working due to CLR limitations.")]
+            public void ManagedCanCallNestedAction()
+            {
+                var action = Library.GetNativeActionT1Nested();
+
+                int result = 0;
+                action(i => result = i);
+
+                Assert.Equal(5, result);
+            }
+
+            [Fact(Skip = "Not working due to CLR limitations.")]
+            public void ManagedCanCallNestedFunc()
+            {
+                var func = Library.GetNativeFuncT1T2Nested();
+
+                int result = 0;
+                func(i => result = i * 5);
+
+                Assert.Equal(25, result);
+            }
+        }
+
+        /*        void ExecuteAction(DelegateLibraryDelegates.Action action);
+
+        void ExecuteActionT1([DelegateLifetime(DelegateLifetime.None)] DelegateLibraryDelegates.ActionInt action);
+
+        void ExecuteActionT1Nested([DelegateLifetime(DelegateLifetime.CallOnly)] DelegateLibraryDelegates.ActinIntInAction action);
+
+        int ExecuteFuncT1([DelegateLifetime] DelegateLibraryDelegates.IntFunc func);*/
+        public class DelegateLifetime : LibraryTestBase<IDelegateLibrary>
+        {
+            private static DelegateLibraryDelegates.Action _keepAliveReference;
+
+            private static WeakReference<DelegateLibraryDelegates.Action> CreateAction
+            (
+                bool keepAlive,
+                Action<DelegateLibraryDelegates.Action> executeAction
+            )
+            {
+                bool ranAction = false;
+                DelegateLibraryDelegates.Action action = () => ranAction = true;
+
+                if (keepAlive)
+                {
+                    _keepAliveReference = action;
+                }
+
+                executeAction(action);
+
+                Assert.True(ranAction);
+                return new WeakReference<DelegateLibraryDelegates.Action>(action);
+            }
+
+            public DelegateLifetime()
+                : base(LibraryName)
+            {
+            }
+
+            [Fact]
+            public void IsDelegateKeptAliveByDefault()
+            {
+                var weakRef = CreateAction(false, x => Library.ExecuteActionDefault(x));
+
+                GC.Collect();
+
+                Assert.True(weakRef.TryGetTarget(out var action));
+            }
+
+            [Fact]
+            public void DefaultLifetimeDelegateGetsNotCollected()
+            {
+                var weakRef = CreateAction(false, x => Library.ExecuteActionLifetimeDefault(x));
+
+                GC.Collect();
+
+                Assert.True(weakRef.TryGetTarget(out var action));
+            }
+
+            [Fact]
+            public void PersistentLifetimeDelegateGetsNotCollected()
+            {
+                var weakRef = CreateAction(false, x => Library.ExecuteActionLifetimePersistent(x));
+
+                GC.Collect();
+
+                Assert.True(weakRef.TryGetTarget(out var action));
+            }
+
+            [Fact]
+            public void NoneLifetimeDelegateGetsCollected()
+            {
+                var weakRef = CreateAction(false, x => Library.ExecuteActionLifetimeNone(x));
+
+                GC.Collect();
+
+                Assert.False(weakRef.TryGetTarget(out var action));
+            }
+
+            [Fact]
+            public void CallOnlyLifetimeDelegateGetsCollected()
+            {
+                var weakRef = CreateAction(false, x => Library.ExecuteActionLifetimeCallOnly(x));
+                GC.Collect();
+
+                Assert.False(weakRef.TryGetTarget(out var action));
+            }
+        }
+    }
+}

--- a/AdvancedDLSupport.Tests/Tests/Integration/DelegateTests.cs
+++ b/AdvancedDLSupport.Tests/Tests/Integration/DelegateTests.cs
@@ -184,8 +184,6 @@ namespace AdvancedDLSupport.Tests.Integration
 
         public class DelegateLifetime : LibraryTestBase<IDelegateLibrary>
         {
-            private static DelegateLibraryDelegates.Action _keepAliveReference;
-
             private static WeakReference<DelegateLibraryDelegates.Action> CreateAction
             (
                 bool keepAlive,
@@ -194,11 +192,6 @@ namespace AdvancedDLSupport.Tests.Integration
             {
                 bool ranAction = false;
                 DelegateLibraryDelegates.Action action = () => ranAction = true;
-
-                if (keepAlive)
-                {
-                    _keepAliveReference = action;
-                }
 
                 executeAction(action);
 

--- a/AdvancedDLSupport.Tests/Tests/Integration/DelegateTests.cs
+++ b/AdvancedDLSupport.Tests/Tests/Integration/DelegateTests.cs
@@ -168,13 +168,6 @@ namespace AdvancedDLSupport.Tests.Integration
             }
         }
 
-        /*        void ExecuteAction(DelegateLibraryDelegates.Action action);
-
-        void ExecuteActionT1([DelegateLifetime(DelegateLifetime.None)] DelegateLibraryDelegates.ActionInt action);
-
-        void ExecuteActionT1Nested([DelegateLifetime(DelegateLifetime.CallOnly)] DelegateLibraryDelegates.ActinIntInAction action);
-
-        int ExecuteFuncT1([DelegateLifetime] DelegateLibraryDelegates.IntFunc func);*/
         public class DelegateLifetime : LibraryTestBase<IDelegateLibrary>
         {
             private static DelegateLibraryDelegates.Action _keepAliveReference;
@@ -211,7 +204,7 @@ namespace AdvancedDLSupport.Tests.Integration
 
                 GC.Collect();
 
-                Assert.True(weakRef.TryGetTarget(out var action));
+                Assert.True(weakRef.TryGetTarget(out var _));
             }
 
             [Fact]
@@ -221,7 +214,7 @@ namespace AdvancedDLSupport.Tests.Integration
 
                 GC.Collect();
 
-                Assert.True(weakRef.TryGetTarget(out var action));
+                Assert.True(weakRef.TryGetTarget(out var _));
             }
 
             [Fact]
@@ -231,7 +224,7 @@ namespace AdvancedDLSupport.Tests.Integration
 
                 GC.Collect();
 
-                Assert.True(weakRef.TryGetTarget(out var action));
+                Assert.True(weakRef.TryGetTarget(out var _));
             }
 
             [Fact]
@@ -241,7 +234,7 @@ namespace AdvancedDLSupport.Tests.Integration
 
                 GC.Collect();
 
-                Assert.False(weakRef.TryGetTarget(out var action));
+                Assert.False(weakRef.TryGetTarget(out var _));
             }
 
             [Fact]
@@ -250,7 +243,7 @@ namespace AdvancedDLSupport.Tests.Integration
                 var weakRef = CreateAction(false, x => Library.ExecuteActionLifetimeCallOnly(x));
                 GC.Collect();
 
-                Assert.False(weakRef.TryGetTarget(out var action));
+                Assert.False(weakRef.TryGetTarget(out var _));
             }
         }
     }

--- a/AdvancedDLSupport.Tests/Tests/Integration/DelegateTests.cs
+++ b/AdvancedDLSupport.Tests/Tests/Integration/DelegateTests.cs
@@ -222,16 +222,6 @@ namespace AdvancedDLSupport.Tests.Integration
             }
 
             [Fact]
-            public void DefaultLifetimeDelegateGetsNotCollected()
-            {
-                var weakRef = CreateAction(false, x => Library.ExecuteActionLifetimeDefault(x));
-
-                GC.Collect();
-
-                Assert.True(weakRef.TryGetTarget(out var _));
-            }
-
-            [Fact]
             public void PersistentLifetimeDelegateGetsNotCollected()
             {
                 var weakRef = CreateAction(false, x => Library.ExecuteActionLifetimePersistent(x));

--- a/AdvancedDLSupport.Tests/Tests/Integration/DelegateTests.cs
+++ b/AdvancedDLSupport.Tests/Tests/Integration/DelegateTests.cs
@@ -71,6 +71,24 @@ namespace AdvancedDLSupport.Tests.Integration
             }
 
             [Fact]
+            public void NativeCanCallActionWithParameterFromManaged()
+            {
+                bool ranAction = false;
+                int result = 0;
+                int input = 13;
+                Library.ExecuteActionT1WithParameter(
+                    x =>
+                        {
+                            ranAction = true;
+                            result = x;
+                        },
+                    input);
+
+                Assert.True(ranAction);
+                Assert.Equal(input, result);
+            }
+
+            [Fact]
             public void NativeCanCallFunc()
             {
                 var result = Library.ExecuteFuncT1(() => 5);
@@ -84,6 +102,17 @@ namespace AdvancedDLSupport.Tests.Integration
                 var result = Library.ExecuteFuncT1T2(x => 5 * x);
 
                 Assert.Equal(25, result);
+            }
+
+            [Fact]
+            public void NativeCanCallFuncWithParameterFromManaged()
+            {
+                int input = 13;
+                var result = Library.ExecuteFuncT1T2WithParameter(
+                    x => 5 * x,
+                    input);
+
+                Assert.Equal(5 * input, result);
             }
 
             [Fact(Skip = "Not working due to CLR limitations.")]

--- a/AdvancedDLSupport.Tests/c/src/GenericDelegateTests.c
+++ b/AdvancedDLSupport.Tests/c/src/GenericDelegateTests.c
@@ -46,23 +46,33 @@ __declspec(dllexport) void ExecuteActionT1(ActionT1 action)
 	action(5);
 }
 
+__declspec(dllexport) void ExecuteActionT1WithParameter(ActionT1 action, int32_t value)
+{
+    action(value);
+}
+
 __declspec(dllexport) void ExecuteActionT1Nested(ActionT1Nested action)
 {
 	fprintf(stdout, "In nested, seeing function pointer as %x", (unsigned int)&NativeActionT1);
 	action(&NativeActionT1);
 }
 
-__declspec(dllexport) int ExecuteFuncT1(FuncT1 func)
+__declspec(dllexport) int32_t ExecuteFuncT1(FuncT1 func)
 {
 	return func();
 }
 
-__declspec(dllexport) int ExecuteFuncT1T2(FuncT1T2 func)
+__declspec(dllexport) int32_t ExecuteFuncT1T2(FuncT1T2 func)
 {
 	return func(5);
 }
 
-__declspec(dllexport) int ExecuteFuncT1T2Nested(FuncT1T2Nested func)
+__declspec(dllexport) int32_t ExecuteFuncT1T2WithParameter(FuncT1T2 func, int32_t value)
+{
+	return func(value);
+}
+
+__declspec(dllexport) int32_t ExecuteFuncT1T2Nested(FuncT1T2Nested func)
 {
 	return func(&NativeFuncT1T2);
 }
@@ -72,7 +82,7 @@ __declspec(dllexport) void NativeAction()
 	fprintf(stdout, "Living in native land!");
 }
 
-__declspec(dllexport) void NativeActionT1(int t1)
+__declspec(dllexport) void NativeActionT1(int32_t t1)
 {
 	fprintf(stdout, "Living in native land, seeing parameter as %d!", t1);
 }
@@ -92,7 +102,7 @@ __declspec(dllexport) ActionT1Nested GetNativeActionT1Nested()
 	return &ExecuteActionT1;
 }
 
-__declspec(dllexport) int NativeFuncT1()
+__declspec(dllexport) int32_t NativeFuncT1()
 {
 	return 5;
 }
@@ -102,7 +112,7 @@ __declspec(dllexport) FuncT1 GetNativeFuncT1()
 	return &NativeFuncT1;
 }
 
-__declspec(dllexport) int NativeFuncT1T2(int t2)
+__declspec(dllexport) int32_t NativeFuncT1T2(int32_t t2)
 {
 	return t2 * 5;
 }

--- a/AdvancedDLSupport.Tests/c/src/GenericDelegateTests.c
+++ b/AdvancedDLSupport.Tests/c/src/GenericDelegateTests.c
@@ -116,3 +116,17 @@ __declspec(dllexport) FuncT1T2Nested GetNativeFuncT1T2Nested()
 {
 	return &ExecuteFuncT1T2;
 }
+
+__declspec(dllexport) Action GetNullDelegate()
+{
+	return NULL;
+}
+
+__declspec(dllexport) int32_t IsNullDelegate(Action action)
+{
+	if (action == NULL)
+	{
+	    return 1;
+	}
+	return 0;
+}

--- a/AdvancedDLSupport/Attributes/DelegateLifetime.cs
+++ b/AdvancedDLSupport/Attributes/DelegateLifetime.cs
@@ -1,5 +1,5 @@
 //
-//  DelegateLifetimeAttribute.cs
+//  DelegateLifetime.cs
 //
 //  Copyright (c) 2018 Firwood Software
 //
@@ -17,29 +17,26 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-using System;
-using JetBrains.Annotations;
-
 namespace AdvancedDLSupport
 {
     /// <summary>
-    /// The delegate lifetime attribute.
+    /// Depicts the delegate lifetime.
     /// </summary>
-    [PublicAPI, AttributeUsage(AttributeTargets.Parameter | AttributeTargets.ReturnValue)]
-    public class DelegateLifetimeAttribute : Attribute
+    public enum DelegateLifetime
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="DelegateLifetimeAttribute"/> class.
+        /// Delegate lifetime needs to be managed by user.
         /// </summary>
-        /// <param name="lifetime">The delegate lifetime.</param>
-        public DelegateLifetimeAttribute(DelegateLifetime lifetime = DelegateLifetime.Persistent)
-        {
-            Lifetime = lifetime;
-        }
+        None,
 
         /// <summary>
-        /// Gets the delegate lifetime.
+        /// Delegate is kept alive till unloading.
         /// </summary>
-        public DelegateLifetime Lifetime { get; }
+        Persistent,
+
+        /// <summary>
+        /// Delegate is alive only for this call.
+        /// </summary>
+        CallOnly,
     }
 }

--- a/AdvancedDLSupport/Attributes/DelegateLifetime.cs
+++ b/AdvancedDLSupport/Attributes/DelegateLifetime.cs
@@ -27,10 +27,11 @@ namespace AdvancedDLSupport
         /// <summary>
         /// Delegate lifetime needs to be managed by user.
         /// </summary>
-        None,
+        UserManaged,
 
         /// <summary>
-        /// Delegate is kept alive till unloading.
+        /// Delegate is kept alive till unloading of the instance that the call is made on is disposed.
+        /// This is the default lifetime management.
         /// </summary>
         Persistent,
 

--- a/AdvancedDLSupport/Attributes/DelegateLifetimeAttribute.cs
+++ b/AdvancedDLSupport/Attributes/DelegateLifetimeAttribute.cs
@@ -1,0 +1,66 @@
+//
+//  DelegateLifetimeAttribute.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using JetBrains.Annotations;
+
+namespace AdvancedDLSupport
+{
+    /// <summary>
+    /// The delegate lifetime attribute.
+    /// </summary>
+    [PublicAPI, AttributeUsage(AttributeTargets.Parameter | AttributeTargets.ReturnValue)]
+    public class DelegateLifetimeAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DelegateLifetimeAttribute"/> class.
+        /// </summary>
+        /// <param name="lifetime">The delegate lifetime.</param>
+        public DelegateLifetimeAttribute(DelegateLifetime lifetime = DelegateLifetime.Persistent)
+        {
+            Lifetime = lifetime;
+        }
+
+        /// <summary>
+        /// Depicts the delegate lifetime.
+        /// </summary>
+        public enum DelegateLifetime
+        {
+            /// <summary>
+            /// Delegate lifetime needs to be managed by user.
+            /// </summary>
+            None,
+
+            /// <summary>
+            /// Delegate is kept alive till unloading.
+            /// </summary>
+            Persistent,
+
+            /// <summary>
+            /// Delegate is alive only for this call.
+            /// </summary>
+            CallOnly,
+        }
+
+        /// <summary>
+        /// Gets the delegate lifetime.
+        /// </summary>
+        public DelegateLifetime Lifetime { get; }
+    }
+}

--- a/AdvancedDLSupport/Attributes/DelegateLifetimeAttribute.cs
+++ b/AdvancedDLSupport/Attributes/DelegateLifetimeAttribute.cs
@@ -32,7 +32,7 @@ namespace AdvancedDLSupport
         /// Initializes a new instance of the <see cref="DelegateLifetimeAttribute"/> class.
         /// </summary>
         /// <param name="lifetime">The delegate lifetime.</param>
-        public DelegateLifetimeAttribute(DelegateLifetime lifetime = DelegateLifetime.Persistent)
+        public DelegateLifetimeAttribute(DelegateLifetime lifetime)
         {
             Lifetime = lifetime;
         }

--- a/AdvancedDLSupport/Extensions/TypeExtensions.cs
+++ b/AdvancedDLSupport/Extensions/TypeExtensions.cs
@@ -32,6 +32,16 @@ namespace AdvancedDLSupport.Extensions
     internal static class TypeExtensions
     {
         /// <summary>
+        /// Determines whether the given type is a delegate type.
+        /// </summary>
+        /// <param name="this">The type.</param>
+        /// <returns>true if the type is a delegate type; Otherwise, false.</returns>
+        public static bool IsDelegate([NotNull] this Type @this)
+        {
+            return typeof(Delegate).IsAssignableFrom(@this);
+        }
+
+        /// <summary>
         /// Determines whether the given type is a generic delegate type - that is, a <see cref="Func{TResult}"/> or
         /// <see cref="Action"/>.
         /// </summary>

--- a/AdvancedDLSupport/ImplementationGenerators/Wrappers/DelegateWrapper.cs
+++ b/AdvancedDLSupport/ImplementationGenerators/Wrappers/DelegateWrapper.cs
@@ -91,12 +91,16 @@ namespace AdvancedDLSupport.ImplementationGenerators
 
                 var lifetime = GetParameterDelegateLifetime(definition.ParameterCustomAttributes[i - 1]);
 
-                if (lifetime != DelegateLifetimeAttribute.DelegateLifetime.CallOnly)
+                if (lifetime == DelegateLifetime.Persistent)
                 {
                     // Load this
                     il.EmitLoadArgument(0);
                     il.EmitLoadArgument(i);
                     il.Emit(OpCodes.Call, allocMethod);
+                }
+                else
+                {
+                    il.EmitLoadArgument(i);
                 }
             }
         }
@@ -153,7 +157,7 @@ namespace AdvancedDLSupport.ImplementationGenerators
         /// <param name="customAttributes">The custom attributes applied to the parameter.</param>
         /// <returns>The delegate lifetime.</returns>
         [Pure]
-        private DelegateLifetimeAttribute.DelegateLifetime GetParameterDelegateLifetime([NotNull, ItemNotNull] IEnumerable<CustomAttributeData> customAttributes)
+        private DelegateLifetime GetParameterDelegateLifetime([NotNull, ItemNotNull] IEnumerable<CustomAttributeData> customAttributes)
         {
             var lifetimeAttribute = customAttributes.FirstOrDefault
             (
@@ -163,8 +167,8 @@ namespace AdvancedDLSupport.ImplementationGenerators
 
             if (lifetimeAttribute is null)
             {
-                // Default to marshalling booleans as 1-byte integers
-                return DelegateLifetimeAttribute.DelegateLifetime.Persistent;
+                // Default to keeping delegates alive
+                return DelegateLifetime.Persistent;
             }
 
             return lifetimeAttribute.ToInstance<DelegateLifetimeAttribute>().Lifetime;

--- a/AdvancedDLSupport/ImplementationGenerators/Wrappers/DelegateWrapper.cs
+++ b/AdvancedDLSupport/ImplementationGenerators/Wrappers/DelegateWrapper.cs
@@ -97,7 +97,7 @@ namespace AdvancedDLSupport.ImplementationGenerators
         /// <inheritdoc />
         public override bool IsApplicable(IntrospectiveMethodInfo member)
         {
-            if (member.ReturnType.IsDelegate() && GetParameterDelegateLifetime(member.ReturnParameterCustomAttributes) == DelegateLifetime.Persistent)
+            if (member.ReturnType.IsDelegate())
             {
                 return true;
             }
@@ -105,7 +105,7 @@ namespace AdvancedDLSupport.ImplementationGenerators
             for (int i = 0; i < member.ParameterTypes.Count; i++)
             {
                 var p = member.ParameterTypes[i];
-                if (p.IsDelegate() && GetParameterDelegateLifetime(member.ParameterCustomAttributes[i]) == DelegateLifetime.Persistent)
+                if (p.IsDelegate())
                 {
                     return true;
                 }

--- a/AdvancedDLSupport/ImplementationGenerators/Wrappers/DelegateWrapper.cs
+++ b/AdvancedDLSupport/ImplementationGenerators/Wrappers/DelegateWrapper.cs
@@ -160,9 +160,9 @@ namespace AdvancedDLSupport.ImplementationGenerators
 
             il.Emit(OpCodes.Ldloc_0);
 
-            _marshalPointerToDel = _marshalPointerToDel.MakeGenericMethod(workUnit.Definition.ReturnType);
+            var marshalPointerToDel = _marshalPointerToDel.MakeGenericMethod(workUnit.Definition.ReturnType);
 
-            il.Emit(OpCodes.Call, _marshalPointerToDel);
+            il.Emit(OpCodes.Call, marshalPointerToDel);
             il.Emit(OpCodes.Ret);
 
             il.MarkLabel(retNullLabel);

--- a/AdvancedDLSupport/ImplementationGenerators/Wrappers/DelegateWrapper.cs
+++ b/AdvancedDLSupport/ImplementationGenerators/Wrappers/DelegateWrapper.cs
@@ -1,0 +1,221 @@
+//
+//  DelegateWrapper.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.InteropServices;
+using AdvancedDLSupport.Extensions;
+using AdvancedDLSupport.Pipeline;
+using AdvancedDLSupport.Reflection;
+using JetBrains.Annotations;
+using StrictEmit;
+using static AdvancedDLSupport.ImplementationGenerators.GeneratorComplexity;
+
+namespace AdvancedDLSupport.ImplementationGenerators
+{
+    /// <summary>
+    /// Generates wrapper instructions for marshalling delegate type.
+    /// </summary>
+    public class DelegateWrapper : CallWrapperBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DelegateWrapper"/> class.
+        /// </summary>
+        /// <param name="targetModule">The module where the implementation should be generated.</param>
+        /// <param name="targetType">The type in which the implementation should be generated.</param>
+        /// <param name="targetTypeConstructorIL">The IL generator for the target type's constructor.</param>
+        /// <param name="options">The configuration object to use.</param>
+        public DelegateWrapper([NotNull] ModuleBuilder targetModule, [NotNull] TypeBuilder targetType, [NotNull] ILGenerator targetTypeConstructorIL, ImplementationOptions options)
+            : base(targetModule, targetType, targetTypeConstructorIL, options)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override GeneratorComplexity Complexity => MemberDependent | TransformsParameters | CreatesTypes;
+
+        /// <inheritdoc />
+        public override bool IsApplicable(IntrospectiveMethodInfo member)
+        {
+            if (member.ReturnType.IsDelegate())
+            {
+                return true;
+            }
+
+            foreach (var p in member.ParameterTypes)
+            {
+                if (p.IsDelegate())
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc/>
+        public override void EmitPrologue(ILGenerator il, PipelineWorkUnit<IntrospectiveMethodInfo> workUnit)
+        {
+            var definition = workUnit.Definition;
+
+            var allocMethod =
+                typeof(NativeLibraryBase).GetMethod("AddLifetimeDelegate", BindingFlags.Instance | BindingFlags.NonPublic);
+            il.EmitLoadArgument(0);
+            for (short i = 1; i <= definition.ParameterTypes.Count; ++i)
+            {
+                var parameterType = definition.ParameterTypes[i - 1];
+
+                if (!parameterType.IsDelegate())
+                {
+                    il.EmitLoadArgument(i);
+                    continue;
+                }
+
+                var lifetime = GetParameterDelegateLifetime(definition.ParameterCustomAttributes[i - 1]);
+
+                if (lifetime != DelegateLifetimeAttribute.DelegateLifetime.CallOnly)
+                {
+                    // Load this
+                    il.EmitLoadArgument(0);
+                    il.EmitLoadArgument(i);
+                    il.Emit(OpCodes.Call, allocMethod);
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void EmitEpilogue(ILGenerator il, PipelineWorkUnit<IntrospectiveMethodInfo> workUnit)
+        {
+            // If the return type is a delegate, convert it back into its generic representation
+            var definition = workUnit.Definition;
+            var returnType = definition.ReturnType;
+
+            if (!returnType.IsDelegate())
+            {
+                return;
+            }
+
+            var marshalPointerToDel = typeof(Marshal).GetMethods(BindingFlags.Public | BindingFlags.Static).FirstOrDefault(x =>
+                x.IsGenericMethodDefinition && x.Name == "GetDelegateForFunctionPointer" && x.GetParameters().Length == 1 && x.GetParameters()[0].ParameterType == typeof(IntPtr));
+
+            if (marshalPointerToDel == null)
+            {
+                throw new InvalidOperationException("Marshal.GetDelegateForFunctionPointer<T>(IntPtr) not found");
+            }
+
+            var intPtrEquality = typeof(IntPtr).GetMethod("op_Equality");
+            var intPtrZero = typeof(IntPtr).GetField("Zero");
+
+            var retNullLabel = il.DefineLabel();
+            var intPtrRetVal = il.DeclareLocal(typeof(IntPtr));
+
+            il.Emit(OpCodes.Stloc_0);
+            il.Emit(OpCodes.Ldloc_0);
+
+            il.Emit(OpCodes.Ldsfld, intPtrZero);
+            il.Emit(OpCodes.Call, intPtrEquality);
+
+            il.Emit(OpCodes.Brtrue_S, retNullLabel);
+
+            il.Emit(OpCodes.Ldloc_0);
+
+            marshalPointerToDel = marshalPointerToDel.MakeGenericMethod(workUnit.Definition.ReturnType);
+
+            il.Emit(OpCodes.Call, marshalPointerToDel);
+            il.Emit(OpCodes.Ret);
+
+            il.MarkLabel(retNullLabel);
+
+            il.Emit(OpCodes.Ldnull);
+        }
+
+        /// <summary>
+        /// Gets the delegate lifetime that the parameter with the given attributes should be marshalled with.
+        /// </summary>
+        /// <param name="customAttributes">The custom attributes applied to the parameter.</param>
+        /// <returns>The delegate lifetime.</returns>
+        [Pure]
+        private DelegateLifetimeAttribute.DelegateLifetime GetParameterDelegateLifetime([NotNull, ItemNotNull] IEnumerable<CustomAttributeData> customAttributes)
+        {
+            var lifetimeAttribute = customAttributes.FirstOrDefault
+            (
+                a =>
+                    a.AttributeType == typeof(DelegateLifetimeAttribute)
+            );
+
+            if (lifetimeAttribute is null)
+            {
+                // Default to marshalling booleans as 1-byte integers
+                return DelegateLifetimeAttribute.DelegateLifetime.Persistent;
+            }
+
+            return lifetimeAttribute.ToInstance<DelegateLifetimeAttribute>().Lifetime;
+        }
+
+        /// <inheritdoc/>
+        public override IntrospectiveMethodInfo GeneratePassthroughDefinition
+        (
+            PipelineWorkUnit<IntrospectiveMethodInfo> workUnit
+        )
+        {
+            var definition = workUnit.Definition;
+
+            var newReturnType = GetParameterPassthroughType(definition.ReturnType);
+            var newParameterTypes = definition.ParameterTypes.Select(GetParameterPassthroughType).ToArray();
+
+            var passthroughMethod = TargetType.DefineMethod
+            (
+                $"{workUnit.GetUniqueBaseMemberName()}_wrapped",
+                MethodAttributes.Private | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+                CallingConventions.Standard,
+                newReturnType,
+                newParameterTypes
+            );
+
+            passthroughMethod.ApplyCustomAttributesFrom(definition, newReturnType, newParameterTypes);
+
+            return new IntrospectiveMethodInfo
+            (
+                passthroughMethod,
+                newReturnType,
+                newParameterTypes,
+                definition.MetadataType,
+                definition
+            );
+        }
+
+        /// <summary>
+        /// Gets the type that the parameter type should be passed through as.
+        /// </summary>
+        /// <param name="originalType">The original type.</param>
+        /// <returns>The passed-through type.</returns>
+        [NotNull]
+        private Type GetParameterPassthroughType([NotNull] Type originalType)
+        {
+            if (originalType.IsDelegate())
+            {
+                return typeof(IntPtr);
+            }
+
+            return originalType;
+        }
+    }
+}

--- a/AdvancedDLSupport/NativeLibraryBase.cs
+++ b/AdvancedDLSupport/NativeLibraryBase.cs
@@ -117,18 +117,9 @@ namespace AdvancedDLSupport
         /// Adds a delegate to keep its lifetime until this library gets disposed.
         /// </summary>
         /// <param name="del">The delegate to keep alive.</param>
-        /// <returns>Returns the marshaled pointer.</returns>
-        protected IntPtr AddLifetimeDelegate(Delegate del)
+        protected void AddLifetimeDelegate(Delegate del)
         {
-            // null delegate does not need to be cached. But IntPtr.Zero is still used in DelegateWrapper.EmitPrologue
-            // and prevents the need of specific IL implementation on each call using DelegateWrapper.
-            if (del == null)
-            {
-                return IntPtr.Zero;
-            }
-
             _delegateStorage.Add(del);
-            return Marshal.GetFunctionPointerForDelegate(del);
         }
 
         /// <inheritdoc />

--- a/AdvancedDLSupport/NativeLibraryBase.cs
+++ b/AdvancedDLSupport/NativeLibraryBase.cs
@@ -33,7 +33,10 @@ namespace AdvancedDLSupport
     [PublicAPI]
     public abstract class NativeLibraryBase : IDisposable
     {
-        private List<Delegate> _delegateStorage = new List<Delegate>();
+        /// <summary>
+        /// Delegate cache storage to keep delegates alive.
+        /// </summary>
+        private HashSet<Delegate> _delegateStorage = new HashSet<Delegate>();
 
         /// <summary>
         /// Gets a value indicating whether or not the library has been disposed.
@@ -111,12 +114,14 @@ namespace AdvancedDLSupport
         }
 
         /// <summary>
-        /// Adds a delegate to keep it's lifetime till this library gets disposed.
+        /// Adds a delegate to keep its lifetime until this library gets disposed.
         /// </summary>
         /// <param name="del">The delegate to keep alive.</param>
         /// <returns>Returns the marshaled pointer.</returns>
         protected IntPtr AddLifetimeDelegate(Delegate del)
         {
+            // null delegate does not need to be cached. But IntPtr.Zero is still used in DelegateWrapper.EmitPrologue
+            // and prevents the need of specific IL implementation on each call using DelegateWrapper.
             if (del == null)
             {
                 return IntPtr.Zero;

--- a/AdvancedDLSupport/Pipeline/ImplementationPipeline.cs
+++ b/AdvancedDLSupport/Pipeline/ImplementationPipeline.cs
@@ -165,6 +165,14 @@ namespace AdvancedDLSupport.Pipeline
                 _options
             );
 
+            yield return new DelegateWrapper
+            (
+                _targetModule,
+                TargetType,
+                _constructorIL,
+                _options
+            );
+
             yield return new SpanMarshallingWrapper
             (
                 _targetModule,


### PR DESCRIPTION
…
### Purpose of this PR

* Using Marshal.GetPointerForDelegate/GetDelegateForFunctionPointer for delegates.
* Keep delegates alive(except for DelegateLifetime.CallOnly)

### Testing status

* Tested on Linux, no new tests. But with my understanding should influence the tests testing GenericDelegates, therefore are automatically tested by these.
* Ran OpenTK tests which did work on Linux with this addition(OpenTK does use explicit delegates, not generic ones)

### Comments

* Needs review at least with naming.
* Still needs testing on Windows.
