### PR TITLE
[WIP] Custom Symbol/Library loading logic

### DIFF
--- a/AdvancedDLSupport.Tests/Data/Classes/LibraryLoadingOverride.cs
+++ b/AdvancedDLSupport.Tests/Data/Classes/LibraryLoadingOverride.cs
@@ -1,0 +1,51 @@
+﻿//
+//  LibraryLoadingOverride.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using AdvancedDLSupport.Loaders;
+using JetBrains.Annotations;
+
+#pragma warning disable SA1600, CS1591
+
+namespace AdvancedDLSupport.Tests.Data.Classes
+{
+    internal class LibraryLoadingOverride : ILibraryLoader
+    {
+        private readonly ILibraryLoader _defaultLoader;
+
+        public bool LoadLibraryCalled { get; private set; }
+
+        public LibraryLoadingOverride(ILibraryLoader @default)
+        {
+            _defaultLoader = @default;
+        }
+
+        public IntPtr LoadLibrary([CanBeNull] string path)
+        {
+            LoadLibraryCalled = true;
+
+            return _defaultLoader.LoadLibrary(path);
+        }
+
+        public bool CloseLibrary(IntPtr library)
+        {
+            return _defaultLoader.CloseLibrary(library);
+        }
+    }
+}

--- a/AdvancedDLSupport.Tests/Data/Classes/SymbolLoadingOverride.cs
+++ b/AdvancedDLSupport.Tests/Data/Classes/SymbolLoadingOverride.cs
@@ -1,0 +1,46 @@
+﻿//
+//  SymbolLoadingOverride.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using AdvancedDLSupport.Loaders;
+using JetBrains.Annotations;
+
+#pragma warning disable SA1600, CS1591
+
+namespace AdvancedDLSupport.Tests.Data.Classes
+{
+    internal class SymbolLoadingOverride : ISymbolLoader
+    {
+        private readonly ISymbolLoader _defaultLoader;
+
+        public bool LoadSymbolCalled { get; private set; }
+
+        public SymbolLoadingOverride(ISymbolLoader @default)
+        {
+            _defaultLoader = @default;
+        }
+
+        public IntPtr LoadSymbol(IntPtr library, [NotNull] string symbolName)
+        {
+            LoadSymbolCalled = true;
+
+            return _defaultLoader.LoadSymbol(library, symbolName == "GetString" ? "GetNullString" : symbolName);
+        }
+    }
+}

--- a/AdvancedDLSupport.Tests/Data/Interfaces/ICustomLoadingLogicTests.cs
+++ b/AdvancedDLSupport.Tests/Data/Interfaces/ICustomLoadingLogicTests.cs
@@ -1,0 +1,30 @@
+﻿//
+//  ICustomLoadingLogicTests.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma warning disable SA1600, CS1591
+
+namespace AdvancedDLSupport.Tests.Data
+{
+    public interface ICustomLoadingLogicTests
+    {
+        int ReturnsOne();
+
+        int ReturnsTwo();
+    }
+}

--- a/AdvancedDLSupport.Tests/Tests/Integration/CustomLoadingLogicTests.cs
+++ b/AdvancedDLSupport.Tests/Tests/Integration/CustomLoadingLogicTests.cs
@@ -1,0 +1,118 @@
+﻿//
+//  CustomLoadingLogicTests.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using AdvancedDLSupport.Loaders;
+using AdvancedDLSupport.Tests.Data;
+using AdvancedDLSupport.Tests.TestBases;
+using JetBrains.Annotations;
+using Xunit;
+
+#pragma warning disable SA1600, CS1591
+
+namespace AdvancedDLSupport.Tests.Integration
+{
+    public class CustomLoadingLogicTests : LibraryTestBase<IStringLibrary>
+    {
+        private const string LibraryName = "StringTests";
+
+        private class LibraryLoadingOverride : ILibraryLoader
+        {
+            private readonly ILibraryLoader _defaultLoader;
+
+            public bool LoadLibraryCalled { get; private set; }
+
+            public LibraryLoadingOverride(ILibraryLoader @default)
+            {
+                _defaultLoader = @default;
+            }
+
+            public IntPtr LoadLibrary([CanBeNull] string path)
+            {
+                LoadLibraryCalled = true;
+
+                return _defaultLoader.LoadLibrary(path);
+            }
+
+            public bool CloseLibrary(IntPtr library)
+            {
+                return _defaultLoader.CloseLibrary(library);
+            }
+        }
+
+        private class SymbolLoadingOverride : ISymbolLoader
+        {
+            private readonly ISymbolLoader _defaultLoader;
+
+            public bool LoadSymbolCalled { get; private set; }
+
+            public SymbolLoadingOverride(ISymbolLoader @default)
+            {
+                _defaultLoader = @default;
+            }
+
+            public IntPtr LoadSymbol(IntPtr library, [NotNull] string symbolName)
+            {
+                LoadSymbolCalled = true;
+
+                return _defaultLoader.LoadSymbol(library, symbolName == "GetString" ? "GetNullString" : symbolName);
+            }
+        }
+
+        private LibraryLoadingOverride _libraryLogicOverride;
+        private SymbolLoadingOverride _symbolLogicOverride;
+
+        public CustomLoadingLogicTests()
+            : base(LibraryName)
+        {
+        }
+
+        protected override ImplementationOptions GetImplementationOptions()
+        {
+            return base.GetImplementationOptions() | ImplementationOptions.UseLazyBinding;
+        }
+
+        protected override NativeLibraryBuilder GetImplementationBuilder()
+        {
+            return base.GetImplementationBuilder().WithLibraryLoader(@default =>
+            {
+                _libraryLogicOverride = new LibraryLoadingOverride(@default);
+                return _libraryLogicOverride;
+            }).WithSymbolLoader(@default =>
+            {
+                _symbolLogicOverride = new SymbolLoadingOverride(@default);
+                return _symbolLogicOverride;
+            });
+        }
+
+        [Fact]
+        public void CustomLogicCalled()
+        {
+            Library.GetString();
+            Assert.True(_libraryLogicOverride.LoadLibraryCalled);
+            Assert.True(_symbolLogicOverride.LoadSymbolCalled);
+        }
+
+        [Fact]
+        public void CustomLogicSuccessful()
+        {
+            Assert.Equal(Library.GetString(), Library.GetNullString());
+        }
+    }
+}

--- a/AdvancedDLSupport.Tests/Tests/Integration/CustomLoadingLogicTests.cs
+++ b/AdvancedDLSupport.Tests/Tests/Integration/CustomLoadingLogicTests.cs
@@ -17,11 +17,9 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-using System;
-using AdvancedDLSupport.Loaders;
 using AdvancedDLSupport.Tests.Data;
+using AdvancedDLSupport.Tests.Data.Classes;
 using AdvancedDLSupport.Tests.TestBases;
-using JetBrains.Annotations;
 using Xunit;
 
 #pragma warning disable SA1600, CS1591
@@ -31,49 +29,6 @@ namespace AdvancedDLSupport.Tests.Integration
     public class CustomLoadingLogicTests : LibraryTestBase<IStringLibrary>
     {
         private const string LibraryName = "StringTests";
-
-        private class LibraryLoadingOverride : ILibraryLoader
-        {
-            private readonly ILibraryLoader _defaultLoader;
-
-            public bool LoadLibraryCalled { get; private set; }
-
-            public LibraryLoadingOverride(ILibraryLoader @default)
-            {
-                _defaultLoader = @default;
-            }
-
-            public IntPtr LoadLibrary([CanBeNull] string path)
-            {
-                LoadLibraryCalled = true;
-
-                return _defaultLoader.LoadLibrary(path);
-            }
-
-            public bool CloseLibrary(IntPtr library)
-            {
-                return _defaultLoader.CloseLibrary(library);
-            }
-        }
-
-        private class SymbolLoadingOverride : ISymbolLoader
-        {
-            private readonly ISymbolLoader _defaultLoader;
-
-            public bool LoadSymbolCalled { get; private set; }
-
-            public SymbolLoadingOverride(ISymbolLoader @default)
-            {
-                _defaultLoader = @default;
-            }
-
-            public IntPtr LoadSymbol(IntPtr library, [NotNull] string symbolName)
-            {
-                LoadSymbolCalled = true;
-
-                return _defaultLoader.LoadSymbol(library, symbolName == "GetString" ? "GetNullString" : symbolName);
-            }
-        }
 
         private LibraryLoadingOverride _libraryLogicOverride;
         private SymbolLoadingOverride _symbolLogicOverride;

--- a/AdvancedDLSupport.Tests/c/src/CustomLoadingLogicTests.c
+++ b/AdvancedDLSupport.Tests/c/src/CustomLoadingLogicTests.c
@@ -1,0 +1,11 @@
+﻿#include <stdint.h>
+
+__declspec(dllexport) int32_t ReturnsOne()
+{
+	return 1;
+}
+
+__declspec(dllexport) int32_t ReturnsTwo()
+{
+	return 2;
+}

--- a/AdvancedDLSupport/Loaders/ILibraryLoader.cs
+++ b/AdvancedDLSupport/Loaders/ILibraryLoader.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using JetBrains.Annotations;
+
+namespace AdvancedDLSupport.Loaders
+{
+    /// <summary>
+    /// Represents a class which can load Libraries on a specific platform.
+    /// </summary>
+    public interface ILibraryLoader
+    {
+        /// <summary>
+        /// Load the given library. A null path signifies intent to load the main executable instead of an external
+        /// library.
+        /// </summary>
+        /// <param name="path">The path to the library.</param>
+        /// <returns>A handle to the library. This value carries no intrinsic meaning.</returns>
+        /// <exception cref="LibraryLoadingException">Thrown if the library could not be loaded.</exception>
+        [PublicAPI]
+        IntPtr LoadLibrary([CanBeNull] string path);
+
+        /// <summary>
+        /// Closes the open handle to the given library.
+        /// </summary>
+        /// <param name="library">The handle to the library to close.</param>
+        /// <returns>true if the library was closed successfully; otherwise, false.</returns>
+        [PublicAPI]
+        bool CloseLibrary(IntPtr library);
+    }
+}

--- a/AdvancedDLSupport/Loaders/ILibraryLoader.cs
+++ b/AdvancedDLSupport/Loaders/ILibraryLoader.cs
@@ -1,4 +1,23 @@
-﻿using System;
+﻿//
+//  ILibraryLoader.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
 using JetBrains.Annotations;
 
 namespace AdvancedDLSupport.Loaders

--- a/AdvancedDLSupport/Loaders/ILibraryLoader.cs
+++ b/AdvancedDLSupport/Loaders/ILibraryLoader.cs
@@ -23,7 +23,7 @@ using JetBrains.Annotations;
 namespace AdvancedDLSupport.Loaders
 {
     /// <summary>
-    /// Represents a class which can load Libraries on a specific platform.
+    /// Represents a class which can load libraries on a specific platform.
     /// </summary>
     public interface ILibraryLoader
     {

--- a/AdvancedDLSupport/Loaders/IPlatformLoader.cs
+++ b/AdvancedDLSupport/Loaders/IPlatformLoader.cs
@@ -17,7 +17,6 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-using System;
 using JetBrains.Annotations;
 
 namespace AdvancedDLSupport.Loaders
@@ -26,44 +25,7 @@ namespace AdvancedDLSupport.Loaders
     /// Represents a class which can load libraries and symbols on a specific platform.
     /// </summary>
     [PublicAPI]
-    public interface IPlatformLoader
+    public interface IPlatformLoader : ISymbolLoader, ILibraryLoader
     {
-        /// <summary>
-        /// Loads the given symbol name and marshals it into a function delegate.
-        /// </summary>
-        /// <param name="library">The library handle.</param>
-        /// <param name="symbolName">The name of the symbol.</param>
-        /// <typeparam name="T">The delegate type to marshal.</typeparam>
-        /// <returns>A marshalled delegate.</returns>
-        [PublicAPI, NotNull, Pure]
-        T LoadFunction<T>(IntPtr library, [NotNull] string symbolName);
-
-        /// <summary>
-        /// Load the given library. A null path signifies intent to load the main executable instead of an external
-        /// library.
-        /// </summary>
-        /// <param name="path">The path to the library.</param>
-        /// <returns>A handle to the library. This value carries no intrinsic meaning.</returns>
-        /// <exception cref="LibraryLoadingException">Thrown if the library could not be loaded.</exception>
-        [PublicAPI]
-        IntPtr LoadLibrary([CanBeNull] string path);
-
-        /// <summary>
-        /// Load the given symbol.
-        /// </summary>
-        /// <param name="library">The handle to the library in which the symbol exists.</param>
-        /// <param name="symbolName">The name of the symbol to load.</param>
-        /// <exception cref="SymbolLoadingException">Thrown if the symbol could not be loaded.</exception>
-        /// <returns>A handle to the symbol.</returns>
-        [PublicAPI, Pure]
-        IntPtr LoadSymbol(IntPtr library, [NotNull] string symbolName);
-
-        /// <summary>
-        /// Closes the open handle to the given library.
-        /// </summary>
-        /// <param name="library">The handle to the library to close.</param>
-        /// <returns>true if the library was closed successfully; otherwise, false.</returns>
-        [PublicAPI]
-        bool CloseLibrary(IntPtr library);
     }
 }

--- a/AdvancedDLSupport/Loaders/ISymbolLoader.cs
+++ b/AdvancedDLSupport/Loaders/ISymbolLoader.cs
@@ -23,7 +23,7 @@ using JetBrains.Annotations;
 namespace AdvancedDLSupport.Loaders
 {
     /// <summary>
-    /// Represents a class which can load Symbols on a specific platform.
+    /// Represents a class which can load symbols on a specific platform.
     /// </summary>
     public interface ISymbolLoader
     {

--- a/AdvancedDLSupport/Loaders/ISymbolLoader.cs
+++ b/AdvancedDLSupport/Loaders/ISymbolLoader.cs
@@ -36,15 +36,5 @@ namespace AdvancedDLSupport.Loaders
         /// <returns>A handle to the symbol.</returns>
         [PublicAPI, Pure]
         IntPtr LoadSymbol(IntPtr library, [NotNull] string symbolName);
-
-        /// <summary>
-        /// Loads the given symbol name and marshals it into a function delegate.
-        /// </summary>
-        /// <param name="library">The library handle.</param>
-        /// <param name="symbolName">The name of the symbol.</param>
-        /// <typeparam name="T">The delegate type to marshal.</typeparam>
-        /// <returns>A marshalled delegate.</returns>
-        [PublicAPI, NotNull, Pure]
-        T LoadFunction<T>(IntPtr library, [NotNull] string symbolName);
     }
 }

--- a/AdvancedDLSupport/Loaders/ISymbolLoader.cs
+++ b/AdvancedDLSupport/Loaders/ISymbolLoader.cs
@@ -1,4 +1,23 @@
-﻿using System;
+﻿//
+//  ISymbolLoader.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
 using JetBrains.Annotations;
 
 namespace AdvancedDLSupport.Loaders

--- a/AdvancedDLSupport/Loaders/ISymbolLoader.cs
+++ b/AdvancedDLSupport/Loaders/ISymbolLoader.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using JetBrains.Annotations;
+
+namespace AdvancedDLSupport.Loaders
+{
+    /// <summary>
+    /// Represents a class which can load Symbols on a specific platform.
+    /// </summary>
+    public interface ISymbolLoader
+    {
+        /// <summary>
+        /// Load the given symbol.
+        /// </summary>
+        /// <param name="library">The handle to the library in which the symbol exists.</param>
+        /// <param name="symbolName">The name of the symbol to load.</param>
+        /// <exception cref="SymbolLoadingException">Thrown if the symbol could not be loaded.</exception>
+        /// <returns>A handle to the symbol.</returns>
+        [PublicAPI, Pure]
+        IntPtr LoadSymbol(IntPtr library, [NotNull] string symbolName);
+
+        /// <summary>
+        /// Loads the given symbol name and marshals it into a function delegate.
+        /// </summary>
+        /// <param name="library">The library handle.</param>
+        /// <param name="symbolName">The name of the symbol.</param>
+        /// <typeparam name="T">The delegate type to marshal.</typeparam>
+        /// <returns>A marshalled delegate.</returns>
+        [PublicAPI, NotNull, Pure]
+        T LoadFunction<T>(IntPtr library, [NotNull] string symbolName);
+    }
+}

--- a/AdvancedDLSupport/Loaders/PlatformLoaderBase.cs
+++ b/AdvancedDLSupport/Loaders/PlatformLoaderBase.cs
@@ -30,7 +30,7 @@ namespace AdvancedDLSupport.Loaders
     public abstract class PlatformLoaderBase : IPlatformLoader
     {
         /// <summary>
-        /// Gets cached instance of the default Plaform Loader.
+        /// Gets a cached instance of the current platform's default loader.
         /// </summary>
         public static IPlatformLoader PlatformLoader { get; } = SelectPlatformLoader();
 

--- a/AdvancedDLSupport/Loaders/PlatformLoaderBase.cs
+++ b/AdvancedDLSupport/Loaders/PlatformLoaderBase.cs
@@ -35,10 +35,6 @@ namespace AdvancedDLSupport.Loaders
         public static IPlatformLoader PlatformLoader { get; } = SelectPlatformLoader();
 
         /// <inheritdoc />
-        public T LoadFunction<T>(IntPtr library, string symbolName) =>
-            Marshal.GetDelegateForFunctionPointer<T>(LoadSymbol(library, symbolName));
-
-        /// <inheritdoc />
         public IntPtr LoadLibrary(string path) => LoadLibraryInternal(path);
 
         /// <summary>

--- a/AdvancedDLSupport/Loaders/PlatformLoaderBase.cs
+++ b/AdvancedDLSupport/Loaders/PlatformLoaderBase.cs
@@ -29,6 +29,11 @@ namespace AdvancedDLSupport.Loaders
     [PublicAPI]
     public abstract class PlatformLoaderBase : IPlatformLoader
     {
+        /// <summary>
+        /// Gets cached instance of the default Plaform Loader.
+        /// </summary>
+        public static IPlatformLoader PlatformLoader { get; } = SelectPlatformLoader();
+
         /// <inheritdoc />
         public T LoadFunction<T>(IntPtr library, string symbolName) =>
             Marshal.GetDelegateForFunctionPointer<T>(LoadSymbol(library, symbolName));
@@ -57,7 +62,7 @@ namespace AdvancedDLSupport.Loaders
         /// <returns>A platform loader for the current platform..</returns>
         /// <exception cref="PlatformNotSupportedException">Thrown if the current platform is not supported.</exception>
         [PublicAPI, NotNull, Pure]
-        public static IPlatformLoader SelectPlatformLoader()
+        private static IPlatformLoader SelectPlatformLoader()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {

--- a/AdvancedDLSupport/NativeLibraryBase.cs
+++ b/AdvancedDLSupport/NativeLibraryBase.cs
@@ -18,6 +18,7 @@
 //
 
 using System;
+using System.Runtime.InteropServices;
 using AdvancedDLSupport.Loaders;
 using JetBrains.Annotations;
 using Mono.DllMap.Extensions;
@@ -96,7 +97,7 @@ namespace AdvancedDLSupport
         /// <typeparam name="T">The delegate to load the symbol as.</typeparam>
         /// <returns>A function delegate.</returns>
         [NotNull]
-        internal T LoadFunction<T>([NotNull] string sym) => SymbolLoader.LoadFunction<T>(_libraryHandle, sym);
+        internal T LoadFunction<T>([NotNull] string sym) => Marshal.GetDelegateForFunctionPointer<T>(LoadSymbol(sym));
 
         /// <summary>
         /// Throws if the library has been disposed.

--- a/AdvancedDLSupport/NativeLibraryBase.cs
+++ b/AdvancedDLSupport/NativeLibraryBase.cs
@@ -57,10 +57,6 @@ namespace AdvancedDLSupport
         private readonly ILibraryLoader _libLoader;
         private readonly ISymbolLoader _symbolLoader;
 
-        private ILibraryLoader LibraryLoader => _libLoader ?? PlatformLoader;
-
-        private ISymbolLoader SymbolLoader => _symbolLoader ?? PlatformLoader;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="NativeLibraryBase"/> class.
         /// </summary>
@@ -80,7 +76,7 @@ namespace AdvancedDLSupport
             _libLoader = libLoader;
             _symbolLoader = symLoader;
             Options = options;
-            _libraryHandle = LibraryLoader.LoadLibrary(path);
+            _libraryHandle = (libLoader ?? PlatformLoader).LoadLibrary(path);
         }
 
         /// <summary>
@@ -88,7 +84,7 @@ namespace AdvancedDLSupport
         /// </summary>
         /// <param name="sym">The symbol name.</param>
         /// <returns>A handle to the symbol.</returns>
-        internal IntPtr LoadSymbol([NotNull] string sym) => SymbolLoader.LoadSymbol(_libraryHandle, sym);
+        internal IntPtr LoadSymbol([NotNull] string sym) => (_symbolLoader ?? PlatformLoader).LoadSymbol(_libraryHandle, sym);
 
         /// <summary>
         /// Forwards the function loading call to the wrapped platform loader.
@@ -123,7 +119,7 @@ namespace AdvancedDLSupport
 
             IsDisposed = true;
 
-            LibraryLoader.CloseLibrary(_libraryHandle);
+            (_libLoader ?? PlatformLoader).CloseLibrary(_libraryHandle);
             _libraryHandle = IntPtr.Zero;
         }
     }

--- a/AdvancedDLSupport/NativeLibraryBase.cs
+++ b/AdvancedDLSupport/NativeLibraryBase.cs
@@ -73,8 +73,8 @@ namespace AdvancedDLSupport
         (
             [CanBeNull] string path,
             ImplementationOptions options,
-            [CanBeNull] ILibraryLoader libLoader,
-            [CanBeNull] ISymbolLoader symLoader
+            [CanBeNull] ILibraryLoader libLoader = null,
+            [CanBeNull] ISymbolLoader symLoader = null
         )
         {
             _libLoader = libLoader;

--- a/AdvancedDLSupport/NativeLibraryBase.cs
+++ b/AdvancedDLSupport/NativeLibraryBase.cs
@@ -43,19 +43,13 @@ namespace AdvancedDLSupport
         /// </summary>
         internal ImplementationOptions Options { get; set; }
 
+        private readonly ILibraryLoader _libraryLoader;
+        private readonly ISymbolLoader _symbolLoader;
+
         /// <summary>
         /// Gets an opaque native handle to the library.
         /// </summary>
         private IntPtr _libraryHandle;
-
-        /// <summary>
-        /// Gets the library and symbol loader for the current platform.
-        /// </summary>
-        [NotNull]
-        private static IPlatformLoader PlatformLoader => PlatformLoaderBase.PlatformLoader;
-
-        private readonly ILibraryLoader _libLoader;
-        private readonly ISymbolLoader _symbolLoader;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NativeLibraryBase"/> class.
@@ -73,10 +67,10 @@ namespace AdvancedDLSupport
             [CanBeNull] ISymbolLoader symLoader = null
         )
         {
-            _libLoader = libLoader ?? PlatformLoader;
-            _symbolLoader = symLoader ?? PlatformLoader;
+            _libraryLoader = libLoader ?? PlatformLoaderBase.PlatformLoader;
+            _symbolLoader = symLoader ?? PlatformLoaderBase.PlatformLoader;
             Options = options;
-            _libraryHandle = _libLoader.LoadLibrary(path);
+            _libraryHandle = _libraryLoader.LoadLibrary(path);
         }
 
         /// <summary>
@@ -119,7 +113,7 @@ namespace AdvancedDLSupport
 
             IsDisposed = true;
 
-            _libLoader.CloseLibrary(_libraryHandle);
+            _libraryLoader.CloseLibrary(_libraryHandle);
             _libraryHandle = IntPtr.Zero;
         }
     }

--- a/AdvancedDLSupport/NativeLibraryBase.cs
+++ b/AdvancedDLSupport/NativeLibraryBase.cs
@@ -73,10 +73,10 @@ namespace AdvancedDLSupport
             [CanBeNull] ISymbolLoader symLoader = null
         )
         {
-            _libLoader = libLoader;
-            _symbolLoader = symLoader;
+            _libLoader = libLoader ?? PlatformLoader;
+            _symbolLoader = symLoader ?? PlatformLoader;
             Options = options;
-            _libraryHandle = (libLoader ?? PlatformLoader).LoadLibrary(path);
+            _libraryHandle = _libLoader.LoadLibrary(path);
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace AdvancedDLSupport
         /// </summary>
         /// <param name="sym">The symbol name.</param>
         /// <returns>A handle to the symbol.</returns>
-        internal IntPtr LoadSymbol([NotNull] string sym) => (_symbolLoader ?? PlatformLoader).LoadSymbol(_libraryHandle, sym);
+        internal IntPtr LoadSymbol([NotNull] string sym) => _symbolLoader.LoadSymbol(_libraryHandle, sym);
 
         /// <summary>
         /// Forwards the function loading call to the wrapped platform loader.
@@ -119,7 +119,7 @@ namespace AdvancedDLSupport
 
             IsDisposed = true;
 
-            (_libLoader ?? PlatformLoader).CloseLibrary(_libraryHandle);
+            _libLoader.CloseLibrary(_libraryHandle);
             _libraryHandle = IntPtr.Zero;
         }
     }

--- a/AdvancedDLSupport/NativeLibraryBase.cs
+++ b/AdvancedDLSupport/NativeLibraryBase.cs
@@ -65,25 +65,9 @@ namespace AdvancedDLSupport
         /// </summary>
         /// <param name="path">The path to the library.</param>
         /// <param name="options">Whether or not this library can be disposed.</param>
-        [PublicAPI, AnonymousConstructor]
-        protected NativeLibraryBase
-        (
-            [CanBeNull] string path,
-            ImplementationOptions options
-        )
-        {
-            Options = options;
-            _libraryHandle = PlatformLoader.LoadLibrary(path);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NativeLibraryBase"/> class.
-        /// </summary>
-        /// <param name="path">The path to the library.</param>
-        /// <param name="options">Whether or not this library can be disposed.</param>
         /// <param name="libLoader">Overriding library loader.</param>
         /// <param name="symLoader">Overriding symbol loader.</param>
-        [PublicAPI]
+        [PublicAPI, AnonymousConstructor]
         protected NativeLibraryBase
         (
             [CanBeNull] string path,

--- a/AdvancedDLSupport/NativeLibraryBuilder.cs
+++ b/AdvancedDLSupport/NativeLibraryBuilder.cs
@@ -497,16 +497,18 @@ namespace AdvancedDLSupport
                 c => c.HasCustomAttribute<AnonymousConstructorAttribute>()
             );
 
+            var anonConstructorParams = anonymousConstructor.GetParameters();
+
             var constructorBuilder = typeBuilder.DefineConstructor
             (
                 Public | SpecialName | RTSpecialName | HideBySig,
                 Standard,
-                anonymousConstructor.GetParameters().Select(p => p.ParameterType).ToArray()
+                anonConstructorParams.Select(p => p.ParameterType).ToArray()
             );
 
             constructorBuilder.DefineParameter(1, ParameterAttributes.In, "libraryPath");
             var constructorIL = constructorBuilder.GetILGenerator();
-            for (var i = 0; i <= anonymousConstructor.GetParameters().Length; ++i)
+            for (var i = 0; i <= anonConstructorParams.Length; ++i)
             {
                 constructorIL.Emit(OpCodes.Ldarg, i);
             }

--- a/AdvancedDLSupport/NativeLibraryBuilder.cs
+++ b/AdvancedDLSupport/NativeLibraryBuilder.cs
@@ -82,6 +82,9 @@ namespace AdvancedDLSupport
         [NotNull]
         private static readonly ConcurrentDictionary<GeneratedImplementationTypeIdentifier, Type> TypeCache;
 
+        private Loaders.ILibraryLoader _customLibLoader;
+        private Loaders.ISymbolLoader _customSymLoader;
+
         static NativeLibraryBuilder()
         {
             TypeCache = new ConcurrentDictionary<GeneratedImplementationTypeIdentifier, Type>
@@ -115,6 +118,28 @@ namespace AdvancedDLSupport
 
             Options = options;
             PathResolver = pathResolver ?? new DynamicLinkLibraryPathResolver();
+        }
+
+        /// <summary>
+        /// Overrides the default symbol loader for this instance of <see cref="NativeLibraryBuilder"/>.
+        /// </summary>
+        /// <param name="factory">Factory to create the overriding symbol loader.</param>
+        /// <returns>This instance of <see cref="NativeLibraryBuilder"/>.</returns>
+        public NativeLibraryBuilder WithSymbolLoader(Func<Loaders.ISymbolLoader, Loaders.ISymbolLoader> factory)
+        {
+            _customSymLoader = factory(Loaders.PlatformLoaderBase.PlatformLoader);
+            return this;
+        }
+
+        /// <summary>
+        /// Overrides the default library loader for this instance of <see cref="NativeLibraryBuilder"/>.
+        /// </summary>
+        /// <param name="factory">Factory to create the overriding library loader.</param>
+        /// <returns>This instance of <see cref="NativeLibraryBuilder"/>.</returns>
+        public NativeLibraryBuilder WithLibraryLoader(Func<Loaders.ILibraryLoader, Loaders.ILibraryLoader> factory)
+        {
+            _customLibLoader = factory(Loaders.PlatformLoaderBase.PlatformLoader);
+            return this;
         }
 
         /// <summary>
@@ -583,14 +608,18 @@ namespace AdvancedDLSupport
         (
             [NotNull] Type finalType,
             [CanBeNull] string library,
-            ImplementationOptions options
+            ImplementationOptions options,
+            Loaders.ILibraryLoader libLoader = null,
+            Loaders.ISymbolLoader symLoader = null
         )
         {
             return Activator.CreateInstance
             (
                 finalType,
                 library,
-                options
+                options,
+                libLoader,
+                symLoader
             );
         }
 

--- a/AdvancedDLSupport/NativeLibraryBuilder.cs
+++ b/AdvancedDLSupport/NativeLibraryBuilder.cs
@@ -27,6 +27,7 @@ using System.Reflection.Emit;
 using AdvancedDLSupport.AOT;
 using AdvancedDLSupport.DynamicAssemblyProviders;
 using AdvancedDLSupport.Extensions;
+using AdvancedDLSupport.Loaders;
 using AdvancedDLSupport.Pipeline;
 using AdvancedDLSupport.Reflection;
 using JetBrains.Annotations;
@@ -82,8 +83,8 @@ namespace AdvancedDLSupport
         [NotNull]
         private static readonly ConcurrentDictionary<GeneratedImplementationTypeIdentifier, Type> TypeCache;
 
-        private Loaders.ILibraryLoader _customLibraryLoader;
-        private Loaders.ISymbolLoader _customSymbolLoader;
+        private ILibraryLoader _customLibraryLoader;
+        private ISymbolLoader _customSymbolLoader;
 
         static NativeLibraryBuilder()
         {
@@ -124,10 +125,10 @@ namespace AdvancedDLSupport
         /// Overrides the default symbol loader for this instance of <see cref="NativeLibraryBuilder"/>.
         /// </summary>
         /// <param name="factory">Factory to create the overriding symbol loader.</param>
-        /// <returns>This instance of <see cref="NativeLibraryBuilder"/>.</returns>
-        public NativeLibraryBuilder WithSymbolLoader(Func<Loaders.ISymbolLoader, Loaders.ISymbolLoader> factory)
+        /// <returns>This instance, with the symbol loader overridden.</returns>
+        public NativeLibraryBuilder WithSymbolLoader(Func<ISymbolLoader, ISymbolLoader> factory)
         {
-            _customSymbolLoader = factory(Loaders.PlatformLoaderBase.PlatformLoader);
+            _customSymbolLoader = factory(PlatformLoaderBase.PlatformLoader);
             return this;
         }
 
@@ -136,9 +137,9 @@ namespace AdvancedDLSupport
         /// </summary>
         /// <param name="factory">Factory to create the overriding library loader.</param>
         /// <returns>This instance of <see cref="NativeLibraryBuilder"/>.</returns>
-        public NativeLibraryBuilder WithLibraryLoader(Func<Loaders.ILibraryLoader, Loaders.ILibraryLoader> factory)
+        public NativeLibraryBuilder WithLibraryLoader(Func<ILibraryLoader, ILibraryLoader> factory)
         {
-            _customLibraryLoader = factory(Loaders.PlatformLoaderBase.PlatformLoader);
+            _customLibraryLoader = factory(PlatformLoaderBase.PlatformLoader);
             return this;
         }
 
@@ -524,18 +525,18 @@ namespace AdvancedDLSupport
                 c => c.HasCustomAttribute<AnonymousConstructorAttribute>()
             );
 
-            var anonConstructorParams = anonymousConstructor.GetParameters();
+            var constructorParams = anonymousConstructor.GetParameters();
 
             var constructorBuilder = typeBuilder.DefineConstructor
             (
                 Public | SpecialName | RTSpecialName | HideBySig,
                 Standard,
-                anonConstructorParams.Select(p => p.ParameterType).ToArray()
+                constructorParams.Select(p => p.ParameterType).ToArray()
             );
 
             constructorBuilder.DefineParameter(1, ParameterAttributes.In, "libraryPath");
             var constructorIL = constructorBuilder.GetILGenerator();
-            for (var i = 0; i <= anonConstructorParams.Length; ++i)
+            for (var i = 0; i <= constructorParams.Length; ++i)
             {
                 constructorIL.Emit(OpCodes.Ldarg, i);
             }
@@ -611,8 +612,8 @@ namespace AdvancedDLSupport
             [NotNull] Type finalType,
             [CanBeNull] string library,
             ImplementationOptions options,
-            Loaders.ILibraryLoader libLoader = null,
-            Loaders.ISymbolLoader symLoader = null
+            ILibraryLoader libLoader = null,
+            ISymbolLoader symLoader = null
         )
         {
             return Activator.CreateInstance

--- a/AdvancedDLSupport/NativeLibraryBuilder.cs
+++ b/AdvancedDLSupport/NativeLibraryBuilder.cs
@@ -383,7 +383,9 @@ namespace AdvancedDLSupport
                     (
                         generatedType,
                         libraryPath,
-                        Options
+                        Options,
+                        _customLibraryLoader,
+                        _customSymbolLoader
                     );
 
                     return anonymousInstance;

--- a/AdvancedDLSupport/NativeLibraryBuilder.cs
+++ b/AdvancedDLSupport/NativeLibraryBuilder.cs
@@ -82,8 +82,8 @@ namespace AdvancedDLSupport
         [NotNull]
         private static readonly ConcurrentDictionary<GeneratedImplementationTypeIdentifier, Type> TypeCache;
 
-        private Loaders.ILibraryLoader _customLibLoader;
-        private Loaders.ISymbolLoader _customSymLoader;
+        private Loaders.ILibraryLoader _customLibraryLoader;
+        private Loaders.ISymbolLoader _customSymbolLoader;
 
         static NativeLibraryBuilder()
         {
@@ -127,7 +127,7 @@ namespace AdvancedDLSupport
         /// <returns>This instance of <see cref="NativeLibraryBuilder"/>.</returns>
         public NativeLibraryBuilder WithSymbolLoader(Func<Loaders.ISymbolLoader, Loaders.ISymbolLoader> factory)
         {
-            _customSymLoader = factory(Loaders.PlatformLoaderBase.PlatformLoader);
+            _customSymbolLoader = factory(Loaders.PlatformLoaderBase.PlatformLoader);
             return this;
         }
 
@@ -138,7 +138,7 @@ namespace AdvancedDLSupport
         /// <returns>This instance of <see cref="NativeLibraryBuilder"/>.</returns>
         public NativeLibraryBuilder WithLibraryLoader(Func<Loaders.ILibraryLoader, Loaders.ILibraryLoader> factory)
         {
-            _customLibLoader = factory(Loaders.PlatformLoaderBase.PlatformLoader);
+            _customLibraryLoader = factory(Loaders.PlatformLoaderBase.PlatformLoader);
             return this;
         }
 


### PR DESCRIPTION
This PR will add the ability for library users to add user loading logic to both library and library symbol loading.

Unfortunately, this is currently untested, Windows tests won't compile on my current setup

With these changes, it is possible to support API's like OpenGL and Vulkan because they export methods to look up the rest of their API's.
