### PR TITLE
Implement our own calli emission

### DIFF
--- a/AdvancedDLSupport/Extensions/ILGeneratorExtensions.cs
+++ b/AdvancedDLSupport/Extensions/ILGeneratorExtensions.cs
@@ -37,29 +37,6 @@ namespace AdvancedDLSupport.Extensions
         private static readonly Action<ILGenerator, OpCode, CallingConvention, Type, Type[]> RealEmitCalli;
 
         /// <summary>
-        /// Holds a delegate wrapping the internal UpdateStackSize method.
-        /// </summary>
-        [CanBeNull]
-        private static readonly Action<ILGenerator, OpCode, int> UpdateStackSize;
-
-        /// <summary>
-        /// Holds a delegate wrapping the internal EnsureCapacity method.
-        /// </summary>
-        [CanBeNull]
-        private static readonly Action<ILGenerator, int> EnsureCapacity;
-
-        /// <summary>
-        /// Holds a delegate wrapping the internal PutInteger4 method.
-        /// </summary>
-        [CanBeNull]
-        private static readonly Action<ILGenerator, int> PutInteger4;
-
-        /// <summary>
-        /// Holds a delegate wrapping the internal GetTokenForSig method.
-        /// </summary>
-        private static readonly Func<ILGenerator, byte[], int> GetTokenForSig;
-
-        /// <summary>
         /// Holds a delegate wrapping an action to retrieve an unmanaged signature helper.
         /// </summary>
         private static readonly Func<CallingConvention, Type, SignatureHelper> GetMethodSignatureHelper;
@@ -86,82 +63,22 @@ namespace AdvancedDLSupport.Extensions
                 return;
             }
 
-            var updateStackSize = ilGeneratorType.GetMethod
-            (
-                "UpdateStackSize",
-                BindingFlags.Instance | BindingFlags.NonPublic,
-                null,
-                new[] { typeof(OpCode), typeof(int) },
-                null
-            );
-
-            var ensureCapacity = ilGeneratorType.GetMethod
-            (
-                "EnsureCapacity",
-                BindingFlags.Instance | BindingFlags.NonPublic,
-                null,
-                new[] { typeof(int) },
-                null
-            );
-
-            var putInteger4 = ilGeneratorType.GetMethod
-            (
-                "PutInteger4",
-                BindingFlags.Instance | BindingFlags.NonPublic,
-                null,
-                new[] { typeof(int) },
-                null
-            );
-
             var getMethodSignatureHelper = typeof(SignatureHelper).GetMethod
             (
                 nameof(SignatureHelper.GetMethodSigHelper),
                 new[] { typeof(CallingConvention), typeof(Type) }
             );
 
-            var getTokenForSig = ilGeneratorType.GetMethod
-            (
-                "GetTokenForSig",
-                BindingFlags.Instance | BindingFlags.NonPublic,
-                null,
-                new[] { typeof(byte[]) },
-                null
-            );
-
-            var lacksAnyRequiredMethod = updateStackSize is null ||
-                                         ensureCapacity is null ||
-                                         putInteger4 is null ||
-                                         getMethodSignatureHelper is null ||
-                                         getTokenForSig is null;
-
-            if (lacksAnyRequiredMethod)
+            if (getMethodSignatureHelper is null)
             {
                 return;
             }
-
-            var updateStackSizeDelegateType = typeof(Action<ILGenerator, OpCode, int>);
-            UpdateStackSize = (Action<ILGenerator, OpCode, int>)Delegate.CreateDelegate
-            (
-                updateStackSizeDelegateType,
-                updateStackSize
-            );
-
-            var simpleIntDelegateType = typeof(Action<ILGenerator, int>);
-            EnsureCapacity = (Action<ILGenerator, int>)Delegate.CreateDelegate(simpleIntDelegateType, ensureCapacity);
-            PutInteger4 = (Action<ILGenerator, int>)Delegate.CreateDelegate(simpleIntDelegateType, putInteger4);
 
             var getHelperDelegateType = typeof(Func<CallingConvention, Type, SignatureHelper>);
             GetMethodSignatureHelper = (Func<CallingConvention, Type, SignatureHelper>)Delegate.CreateDelegate
             (
                 getHelperDelegateType,
                 getMethodSignatureHelper
-            );
-
-            var getTokenForSigDelegateType = typeof(Func<ILGenerator, byte[], int>);
-            GetTokenForSig = (Func<ILGenerator, byte[], int>)Delegate.CreateDelegate
-            (
-                getTokenForSigDelegateType,
-                getTokenForSig
             );
         }
 
@@ -187,7 +104,7 @@ namespace AdvancedDLSupport.Extensions
                 return;
             }
 
-            if (EnsureCapacity is null || PutInteger4 is null || UpdateStackSize is null || GetMethodSignatureHelper is null)
+            if (GetMethodSignatureHelper is null)
             {
                 throw new PlatformNotSupportedException("Calli is not supported on this runtime.");
             }

--- a/AdvancedDLSupport/Extensions/ILGeneratorExtensions.cs
+++ b/AdvancedDLSupport/Extensions/ILGeneratorExtensions.cs
@@ -89,7 +89,6 @@ namespace AdvancedDLSupport.Extensions
         /// <param name="callingConvention">The unmanaged calling convention to use.</param>
         /// <param name="returnType">The method's signature.</param>
         /// <param name="parameterTypes">The method's parameter types.</param>
-        /// <remarks>This method is based on the .NET Core 2.1 implementation of EmitCalli.</remarks>
         public static void EmitCalli
         (
             this ILGenerator @this,

--- a/AdvancedDLSupport/Extensions/ILGeneratorExtensions.cs
+++ b/AdvancedDLSupport/Extensions/ILGeneratorExtensions.cs
@@ -28,7 +28,7 @@ namespace AdvancedDLSupport.Extensions
     /// <summary>
     /// Extension methods for the <see cref="ILGenerator"/> class.
     /// </summary>
-    public static class ILGeneratorExtensions
+    internal static class ILGeneratorExtensions
     {
         /// <summary>
         /// Holds the real EmitCalli overload, if it exists on this runtime.
@@ -172,6 +172,7 @@ namespace AdvancedDLSupport.Extensions
         /// <param name="callingConvention">The unmanaged calling convention to use.</param>
         /// <param name="returnType">The method's signature.</param>
         /// <param name="parameterTypes">The method's parameter types.</param>
+        /// <remarks>This method is based on the .NET Core 2.1 implementation of EmitCalli.</remarks>
         public static void EmitCalli
         (
             this ILGenerator @this,
@@ -191,7 +192,6 @@ namespace AdvancedDLSupport.Extensions
                 throw new PlatformNotSupportedException("Calli is not supported on this runtime.");
             }
 
-            var parameterCount = parameterTypes?.Length ?? 0;
             var sig = GetMethodSignatureHelper(callingConvention, returnType);
 
             if (!(parameterTypes is null))
@@ -202,22 +202,7 @@ namespace AdvancedDLSupport.Extensions
                 }
             }
 
-            // Push one if we have a return type
-            var stackChange = 0;
-            if (returnType != typeof(void))
-            {
-                ++stackChange;
-            }
-
-            // Pop off the arguments
-            stackChange -= parameterCount;
-            UpdateStackSize(@this, OpCodes.Calli, stackChange);
-
-            EnsureCapacity(@this, 7);
-            @this.Emit(OpCodes.Calli);
-
-            var token = GetTokenForSig(@this, sig.GetSignature());
-            PutInteger4(@this, token);
+            @this.Emit(OpCodes.Calli, sig);
         }
     }
 }

--- a/AdvancedDLSupport/Extensions/ILGeneratorExtensions.cs
+++ b/AdvancedDLSupport/Extensions/ILGeneratorExtensions.cs
@@ -1,0 +1,223 @@
+//
+//  ILGeneratorExtensions.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.InteropServices;
+using JetBrains.Annotations;
+
+namespace AdvancedDLSupport.Extensions
+{
+    /// <summary>
+    /// Extension methods for the <see cref="ILGenerator"/> class.
+    /// </summary>
+    public static class ILGeneratorExtensions
+    {
+        /// <summary>
+        /// Holds the real EmitCalli overload, if it exists on this runtime.
+        /// </summary>
+        [CanBeNull]
+        private static readonly Action<ILGenerator, OpCode, CallingConvention, Type, Type[]> RealEmitCalli;
+
+        /// <summary>
+        /// Holds a delegate wrapping the internal UpdateStackSize method.
+        /// </summary>
+        [CanBeNull]
+        private static readonly Action<ILGenerator, OpCode, int> UpdateStackSize;
+
+        /// <summary>
+        /// Holds a delegate wrapping the internal EnsureCapacity method.
+        /// </summary>
+        [CanBeNull]
+        private static readonly Action<ILGenerator, int> EnsureCapacity;
+
+        /// <summary>
+        /// Holds a delegate wrapping the internal PutInteger4 method.
+        /// </summary>
+        [CanBeNull]
+        private static readonly Action<ILGenerator, int> PutInteger4;
+
+        /// <summary>
+        /// Holds a delegate wrapping the internal GetTokenForSig method.
+        /// </summary>
+        private static readonly Func<ILGenerator, byte[], int> GetTokenForSig;
+
+        /// <summary>
+        /// Holds a delegate wrapping an action to retrieve an unmanaged signature helper.
+        /// </summary>
+        private static readonly Func<CallingConvention, Type, SignatureHelper> GetMethodSignatureHelper;
+
+        static ILGeneratorExtensions()
+        {
+            var ilGeneratorType = typeof(ILGenerator);
+
+            var realEmitCalli = ilGeneratorType.GetMethod
+            (
+                nameof(ILGenerator.EmitCalli),
+                new[] { typeof(OpCode), typeof(CallingConvention), typeof(Type), typeof(Type[]) }
+            );
+
+            if (!(realEmitCalli is null))
+            {
+                var delegateType = typeof(Action<ILGenerator, OpCode, CallingConvention, Type, Type[]>);
+                RealEmitCalli = (Action<ILGenerator, OpCode, CallingConvention, Type, Type[]>)Delegate.CreateDelegate
+                (
+                    delegateType,
+                    realEmitCalli
+                );
+
+                return;
+            }
+
+            var updateStackSize = ilGeneratorType.GetMethod
+            (
+                "UpdateStackSize",
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                null,
+                new[] { typeof(OpCode), typeof(int) },
+                null
+            );
+
+            var ensureCapacity = ilGeneratorType.GetMethod
+            (
+                "EnsureCapacity",
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                null,
+                new[] { typeof(int) },
+                null
+            );
+
+            var putInteger4 = ilGeneratorType.GetMethod
+            (
+                "PutInteger4",
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                null,
+                new[] { typeof(int) },
+                null
+            );
+
+            var getMethodSignatureHelper = typeof(SignatureHelper).GetMethod
+            (
+                nameof(SignatureHelper.GetMethodSigHelper),
+                new[] { typeof(CallingConvention), typeof(Type) }
+            );
+
+            var getTokenForSig = ilGeneratorType.GetMethod
+            (
+                "GetTokenForSig",
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                null,
+                new[] { typeof(byte[]) },
+                null
+            );
+
+            var lacksAnyRequiredMethod = updateStackSize is null ||
+                                         ensureCapacity is null ||
+                                         putInteger4 is null ||
+                                         getMethodSignatureHelper is null ||
+                                         getTokenForSig is null;
+
+            if (lacksAnyRequiredMethod)
+            {
+                return;
+            }
+
+            var updateStackSizeDelegateType = typeof(Action<ILGenerator, OpCode, int>);
+            UpdateStackSize = (Action<ILGenerator, OpCode, int>)Delegate.CreateDelegate
+            (
+                updateStackSizeDelegateType,
+                updateStackSize
+            );
+
+            var simpleIntDelegateType = typeof(Action<ILGenerator, int>);
+            EnsureCapacity = (Action<ILGenerator, int>)Delegate.CreateDelegate(simpleIntDelegateType, ensureCapacity);
+            PutInteger4 = (Action<ILGenerator, int>)Delegate.CreateDelegate(simpleIntDelegateType, putInteger4);
+
+            var getHelperDelegateType = typeof(Func<CallingConvention, Type, SignatureHelper>);
+            GetMethodSignatureHelper = (Func<CallingConvention, Type, SignatureHelper>)Delegate.CreateDelegate
+            (
+                getHelperDelegateType,
+                getMethodSignatureHelper
+            );
+
+            var getTokenForSigDelegateType = typeof(Func<ILGenerator, byte[], int>);
+            GetTokenForSig = (Func<ILGenerator, byte[], int>)Delegate.CreateDelegate
+            (
+                getTokenForSigDelegateType,
+                getTokenForSig
+            );
+        }
+
+        /// <summary>
+        /// Emits the IL required to perform an unmanaged indirect call to a method with the given signature.
+        /// </summary>
+        /// <param name="this">The generator to use.</param>
+        /// <param name="callingConvention">The unmanaged calling convention to use.</param>
+        /// <param name="returnType">The method's signature.</param>
+        /// <param name="parameterTypes">The method's parameter types.</param>
+        public static void EmitCalli
+        (
+            this ILGenerator @this,
+            CallingConvention callingConvention,
+            Type returnType,
+            Type[] parameterTypes
+        )
+        {
+            if (!(RealEmitCalli is null))
+            {
+                RealEmitCalli(@this, OpCodes.Calli, callingConvention, returnType, parameterTypes);
+                return;
+            }
+
+            if (EnsureCapacity is null || PutInteger4 is null || UpdateStackSize is null || GetMethodSignatureHelper is null)
+            {
+                throw new PlatformNotSupportedException("Calli is not supported on this runtime.");
+            }
+
+            var parameterCount = parameterTypes?.Length ?? 0;
+            var sig = GetMethodSignatureHelper(callingConvention, returnType);
+
+            if (!(parameterTypes is null))
+            {
+                foreach (var parameterType in parameterTypes)
+                {
+                    sig.AddArgument(parameterType);
+                }
+            }
+
+            // Push one if we have a return type
+            var stackChange = 0;
+            if (returnType != typeof(void))
+            {
+                ++stackChange;
+            }
+
+            // Pop off the arguments
+            stackChange -= parameterCount;
+            UpdateStackSize(@this, OpCodes.Calli, stackChange);
+
+            EnsureCapacity(@this, 7);
+            @this.Emit(OpCodes.Calli);
+
+            var token = GetTokenForSig(@this, sig.GetSignature());
+            PutInteger4(@this, token);
+        }
+    }
+}

--- a/AdvancedDLSupport/ImplementationGenerators/Terminating/IndirectCallMethodImplementationGenerator.cs
+++ b/AdvancedDLSupport/ImplementationGenerators/Terminating/IndirectCallMethodImplementationGenerator.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.InteropServices;
+using AdvancedDLSupport.Extensions;
 using AdvancedDLSupport.Pipeline;
 using AdvancedDLSupport.Reflection;
 using JetBrains.Annotations;
@@ -167,18 +168,7 @@ namespace AdvancedDLSupport.ImplementationGenerators
 
             GenerateSymbolPush(methodIL, backingField);
 
-            // HACK: Workaround for missing overload of EmitCalli
-            if (_calliOverload is null)
-            {
-                // Use the existing overload - things may break
-                methodIL.EmitCalli(OpCodes.Calli, Standard, method.ReturnType, method.ParameterTypes.ToArray(), null);
-            }
-            else
-            {
-                // Use the correct overload via reflection
-                _calliOverload.Invoke(methodIL, new object[] { OpCodes.Calli, callingConvention, method.ReturnType, method.ParameterTypes.ToArray() });
-            }
-
+            methodIL.EmitCalli(callingConvention, method.ReturnType, method.ParameterTypes.ToArray());
             methodIL.EmitReturn();
         }
     }

--- a/AdvancedDLSupport/ImplementationGenerators/Terminating/IndirectCallMethodImplementationGenerator.cs
+++ b/AdvancedDLSupport/ImplementationGenerators/Terminating/IndirectCallMethodImplementationGenerator.cs
@@ -32,7 +32,6 @@ using StrictEmit;
 
 using static AdvancedDLSupport.ImplementationGenerators.GeneratorComplexity;
 using static AdvancedDLSupport.ImplementationOptions;
-using static System.Reflection.CallingConventions;
 
 // ReSharper disable BitwiseOperatorOnEnumWithoutFlags
 namespace AdvancedDLSupport.ImplementationGenerators
@@ -44,9 +43,6 @@ namespace AdvancedDLSupport.ImplementationGenerators
     {
         /// <inheritdoc/>
         public override GeneratorComplexity Complexity => OptionDependent | Terminating;
-
-        [CanBeNull]
-        private readonly MethodInfo _calliOverload;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IndirectCallMethodImplementationGenerator"/> class.
@@ -64,11 +60,6 @@ namespace AdvancedDLSupport.ImplementationGenerators
         )
             : base(targetModule, targetType, targetTypeConstructorIL, options)
         {
-            _calliOverload = typeof(ILGenerator).GetMethod
-            (
-                nameof(ILGenerator.EmitCalli),
-                new[] { typeof(OpCode), typeof(CallingConvention), typeof(Type), typeof(Type[]) }
-            );
         }
 
         /// <inheritdoc/>

--- a/stylecop.json
+++ b/stylecop.json
@@ -25,7 +25,8 @@
         "namingRules" : {
             "allowCommonHungarianPrefixes" : true,
             "allowedHungarianPrefixes" : [
-                "gl"
+                "gl",
+                "il"
             ]
         },
         "maintainabilityRules" : {


### PR DESCRIPTION
### Purpose of this PR

* Implements the missing overload for EmitCalli by using the internals of ILGenerator
* Uses the real overload if it's present.

### Testing status

* Covered by existing unit tests.

### Comments

This PR is a second go at #82, which attempts to fix the issue in a more reliable and backwards-compatible fashion. Instead of simply throwing if there's no exposed EmitCalli method on the ILGenerator type, we can now perform the required emission ourselves, provided we have access to an internal method on SignatureHelper that accepts an unmanaged calling convention.

This should enable even .NET Core 2.0 to use calli properly.
